### PR TITLE
Optimization

### DIFF
--- a/restman/manifest.json
+++ b/restman/manifest.json
@@ -8,7 +8,7 @@
     "32": "res/icon32.png",
     "64": "res/icon64.png"
   },
-  "background": {"scripts": ["js/background.js"]},
+  "background": {"scripts": ["js/background.js"], "persistent": false},
   "permissions": ["tabs", "http://*/", "http://*/*", "https://*/", "https://*/*"],
   "browser_action": {
     "default_icon": "res/icon32.png",


### PR DESCRIPTION
This will transform background.js into eventPage, because that's what it actually is.
This way Opera will load extension only when it will be clicked on, it won't keep extension in memory any other time.
[Reference](https://dev.opera.com/extensions/architecture-overview/#the-background-process)